### PR TITLE
Updated node version

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,6 +1,6 @@
-FROM node:10.19.0-slim
+FROM node:16-slim
 RUN apt-get update 
-RUN apt-get install -y jq zip build-essential python2.7 python2.7-dev git curl
-RUN ln /usr/bin/python2.7 /usr/bin/python2 
-RUN curl -O  https://bootstrap.pypa.io/pip/2.7/get-pip.py && python2.7 get-pip.py && rm get-pip.py
-RUN pip install awscli
+RUN apt-get install -y jq zip build-essential git curl python3.7 python3-pip
+RUN ln /usr/bin/python3.7 /usr/bin/python
+RUN ln /usr/bin/pip3 /usr/bin/pip
+RUN pip3 install awscli


### PR DESCRIPTION
Updated image for circleci. Node version compatible with serverless v3 used for incoming update to translations-api. Could be release as version 1.1.0.